### PR TITLE
Autoconfiguring aspects in Symfony 3.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 sudo: false
 
 env:
+  - SYMFONY_VERSION=v2
   - SYMFONY_VERSION=v3
   - SYMFONY_VERSION=v4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
 sudo: false
 
 env:
-  - SYMFONY_VERSION=v2
   - SYMFONY_VERSION=v3
   - SYMFONY_VERSION=v4
 

--- a/DependencyInjection/GoAopExtension.php
+++ b/DependencyInjection/GoAopExtension.php
@@ -11,6 +11,7 @@
 namespace Go\Symfony\GoAopBundle\DependencyInjection;
 
 
+use Go\Aop\Aspect;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -70,6 +71,13 @@ class GoAopExtension extends Extension
             $container
                 ->getDefinition('goaop.bridge.doctrine.metadata_load_interceptor')
                 ->addTag('doctrine.event_subscriber');
+        }
+
+        // Service autoconfiguration is available in Symfony 3.3+
+        if (method_exists($container, 'registerForAutoconfiguration')) {
+            $container
+                ->registerForAutoconfiguration(Aspect::class)
+                ->addTag('goaop.aspect');
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ services:
             - { name: goaop.aspect }
 ```
 
+If you're using Symfony 3.3+ with autowired and autoconfigured services, your aspects will be 
+registered automatically.
+
 Known issues and workarounds
 ----------------------------
 

--- a/Tests/DependencyInjection/GoAopExtensionTest.php
+++ b/Tests/DependencyInjection/GoAopExtensionTest.php
@@ -10,9 +10,9 @@
 
 namespace Go\Symfony\GoAopBundle\Tests\DependencyInjection;
 
+use Go\Aop\Aspect;
 use Go\Symfony\GoAopBundle\DependencyInjection\GoAopExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Class GoAopExtensionTest
@@ -87,6 +87,22 @@ class GoAopExtensionTest extends AbstractExtensionTestCase
         ]);
 
         $this->assertContainerBuilderHasServiceDefinitionWithTag('goaop.bridge.doctrine.metadata_load_interceptor', 'doctrine.event_subscriber');
+    }
+
+    /**
+     * @test
+     */
+    public function itRegistersAspectInterfaceForAutoconfiguration()
+    {
+        if (!method_exists($this->container, 'getAutoconfiguredInstanceof')) {
+            $this->markTestSkipped('Service autoconfiguration is available in Symfony 3.3+');
+        }
+
+        $this->load();
+
+        $autoconfigure = $this->container->getAutoconfiguredInstanceof();
+
+        $this->assertTrue($autoconfigure[Aspect::class]->hasTag('goaop.aspect'));
     }
 
     /**


### PR DESCRIPTION
Automatically adding the `goaop.aspect` tag to all services that implement the `Aspect` interface.