### PR TITLE
Remove useless parameters

### DIFF
--- a/DependencyInjection/GoAopExtension.php
+++ b/DependencyInjection/GoAopExtension.php
@@ -47,6 +47,10 @@ class GoAopExtension extends Extension
      */
     public function load(array $config, ContainerBuilder $container)
     {
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.xml');
+        $loader->load('commands.xml');
+
         $configurator = new Configuration();
         $config       = $this->processConfiguration($configurator, $config);
 
@@ -57,10 +61,6 @@ class GoAopExtension extends Extension
             $normalizedOptions[$optionKey] = $value;
         }
         $container->setParameter('goaop.options', $normalizedOptions);
-
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('services.xml');
-        $loader->load('commands.xml');
 
         if ($config['cache_warmer']) {
             $definition = $container->getDefinition('goaop.cache.warmer');

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter id="goaop.options" type="collection"/>
+        <parameter key="goaop.options" type="collection"/>
     </parameters>
 
     <services>


### PR DESCRIPTION
This is a small bugfix in fact.
Without this change, we have an _invisible_ error in the `ParameterBag` of Symfony container.
Because this parameter create an integer key and this can cause some problems.
All key of this parameter must be string.

Currently we have something like this:
![image](https://user-images.githubusercontent.com/2140469/35989448-6e4185f0-0d01-11e8-9614-a64ba1dc2401.png)


Without parameters we remove integer key:
![image](https://user-images.githubusercontent.com/2140469/35989548-b4b105d8-0d01-11e8-812f-3b0a0471751b.png)

Please do a release after merge.